### PR TITLE
Destroy peer on close

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rtc-pair-socket",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rtc-pair-socket",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@types/aes-js": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtc-pair-socket",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A WebSocket-like api for secure P2P communication.",
   "main": "dist/src/index.js",
   "scripts": {


### PR DESCRIPTION
This is some housekeeping that was missed in the original version. It becomes important when you want to re-establish a connection, which I noticed in the upcoming N-parties demo.